### PR TITLE
Rudimentary Skewing Support

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -38,7 +38,7 @@
 	<haxelib name="flixel" />
 
 	<!--In case you want to use the addons package-->
-	<!--<haxelib name="flixel-addons" />-->
+	<haxelib name="flixel-addons" />
 
 	<!--In case you want to use the ui package-->
 	<!--<haxelib name="flixel-ui" />-->

--- a/hxformat.json
+++ b/hxformat.json
@@ -1,0 +1,16 @@
+{
+	"lineEnds": {
+		"leftCurly": "both",
+		"rightCurly": "both",
+		"emptyCurly": "break",
+		"objectLiteralCurly": {
+			"leftCurly": "after"
+		}
+	},
+	"sameLine": {
+		"ifElse": "next",
+		"doWhile": "next",
+		"tryBody": "next",
+		"tryCatch": "next"
+	}
+}

--- a/source/AssetPaths.hx
+++ b/source/AssetPaths.hx
@@ -1,4 +1,6 @@
 package;
 
 @:build(flixel.system.FlxAssets.buildFileReferences("assets", true))
-class AssetPaths {}
+class AssetPaths
+{
+}

--- a/source/DinoSprite.hx
+++ b/source/DinoSprite.hx
@@ -1,7 +1,8 @@
-package ;
+package;
 
 import flixel.FlxSprite;
 import flixel.system.FlxAssets.FlxGraphicAsset;
+import flixel.addons.effects.FlxSkewedSprite;
 
 /**
  * ...
@@ -12,22 +13,19 @@ import flixel.system.FlxAssets.FlxGraphicAsset;
  * Twitter: https://twitter.com/ArksDigital
  * Dino Characters on itch.io : https://arks.itch.io/dino-characters
  */
-class DinoSprite extends FlxSprite 
+class DinoSprite extends FlxSkewedSprite
 {
-
-	public function new(?X:Float=0, ?Y:Float=0, ?SimpleGraphic:FlxGraphicAsset) 
+	public function new(?X:Float = 0, ?Y:Float = 0, ?SimpleGraphic:FlxGraphicAsset)
 	{
 		super(X, Y, SimpleGraphic);
-		
+
 		loadGraphic("assets/images/dino.png", true, 24, 24);
-		
+
 		animation.add("idle", [0, 1, 2, 3], 7);
 		animation.add("move", [4, 5, 6, 7, 8, 9], 7);
 		animation.add("kick", [10, 11, 12], 7);
 		animation.add("hurt", [13, 14, 15, 16], 7);
 		animation.add("crouch", [17], 1);
-		animation.add("sneak", [18, 19, 20, 21, 22, 23], 7 );
-		
+		animation.add("sneak", [18, 19, 20, 21, 22, 23], 7);
 	}
-	
 }

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -7,7 +7,6 @@ import com.spikything.utils.MouseWheelTrap;
 
 class Main extends Sprite
 {
-
 	public function new()
 	{
 		super();
@@ -19,11 +18,11 @@ class Main extends Sprite
 		#end
 
 		/**
-		* Add the following code snippet to your project to use the FlxSprite Inspector.
-		*
-		* @param launchInspector Set to `true` to launch the FlxSprite Inspector, or `false` to launch your game.
-		*/
-		var launchInspector :Bool = true;
+		 * Add the following code snippet to your project to use the FlxSprite Inspector.
+		 *
+		 * @param launchInspector Set to `true` to launch the FlxSprite Inspector, or `false` to launch your game.
+		 */
+		var launchInspector:Bool = true;
 
 		if (launchInspector)
 		{
@@ -31,10 +30,7 @@ class Main extends Sprite
 			return;
 		}
 		// End of code snippet
-		
+
 		addChild(new FlxGame(0, 0, PlayState));
-
 	}
-
 }
-

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -15,6 +15,5 @@ class PlayState extends FlxState
 	override public function update(elapsed:Float)
 	{
 		super.update(elapsed);
-
 	}
 }

--- a/source/helpers/FlxSpriteInpsector.hx
+++ b/source/helpers/FlxSpriteInpsector.hx
@@ -13,42 +13,40 @@ import helpers.graphics.DebugPoint;
 using flixel.util.FlxSpriteUtil;
 
 /**
- *----------------------------------------------------------------------------------------
- * Helper class for inspecting and manipulating properties of a sprite in HaxeFlixel.
- *----------------------------------------------------------------------------------------
- * @author Harpwood Studio
- * https://harpwood.itch.io/
- *----------------------------------------------------------------------------------------
- * Instructions:
- * 1. In the constructor, below the 'super.create();' line, replace 'DinoSprite' with the
- * 	  name of your custom FlxSprite class.
- * 2. Determine the desired values for offset, origin, and angle for your sprite.
- * 3. Implement these values in your sprite within your game.
- *----------------------------------------------------------------------------------------
- * Controls:
- * H						  : Toggle help visibility on/off
- * Mouse Wheel                : Zoom in/out.
- * Arrow Keys                 : Move the offset of the sprite by one pixel.
- * Shift + Arrow Keys         : Move the offset of the sprite by multiple pixels.
- *                              The amount will vary based on the zoom level.
- * Alt + Arrow Keys           : Move the origin of the sprite by one pixel.
- * Alt + Shift + Arrow Keys   : Move the origin of the sprite by multiple pixels.
- *                              The amount will vary based on the zoom level.
- * Ctrl + Arrow Keys          : Adjust the size of the sprite's hitbox by one pixel.
- * Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by multiple pixels.
- *                              The amount will vary based on the zoom level.
- * Space                      : Resets all changes.
- * R                          : Toggle sprite rotation on/off.
- * A                          : Show and play previous animation.
- * D                          : Show and play next animation.
- * B                          : Darken the background.
- * Shift + B                  : Lighten the background.
- *----------------------------------------------------------------------------------------
+	*----------------------------------------------------------------------------------------
+	* Helper class for inspecting and manipulating properties of a sprite in HaxeFlixel.
+	*----------------------------------------------------------------------------------------
+	* @author Harpwood Studio
+	* https://harpwood.itch.io/
+	*----------------------------------------------------------------------------------------
+	* Instructions:
+	* 1. In the constructor, below the 'super.create();' line, replace 'DinoSprite' with the
+	* 	  name of your custom FlxSprite class.
+	* 2. Determine the desired values for offset, origin, and angle for your sprite.
+	* 3. Implement these values in your sprite within your game.
+	*----------------------------------------------------------------------------------------
+	* Controls:
+	* H						  : Toggle help visibility on/off
+	* Mouse Wheel                : Zoom in/out.
+	* Arrow Keys                 : Move the offset of the sprite by one pixel.
+	* Shift + Arrow Keys         : Move the offset of the sprite by multiple pixels.
+	*                              The amount will vary based on the zoom level.
+	* Alt + Arrow Keys           : Move the origin of the sprite by one pixel.
+	* Alt + Shift + Arrow Keys   : Move the origin of the sprite by multiple pixels.
+	*                              The amount will vary based on the zoom level.
+	* Ctrl + Arrow Keys          : Adjust the size of the sprite's hitbox by one pixel.
+	* Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by multiple pixels.
+	*                              The amount will vary based on the zoom level.
+	* Space                      : Resets all changes.
+	* R                          : Toggle sprite rotation on/off.
+	* A                          : Show and play previous animation.
+	* D                          : Show and play next animation.
+	* B                          : Darken the background.
+	* Shift + B                  : Lighten the background.
+	*----------------------------------------------------------------------------------------
  */
-
 class FlxSpriteInpsector extends FlxState
 {
-
 	// Camera variables
 	var uiCamera:FlxCamera;
 	var gCamera:FlxCamera;
@@ -59,12 +57,12 @@ class FlxSpriteInpsector extends FlxState
 	var originText:FlxText;
 	var widthText:FlxText;
 	var heightText:FlxText;
+	var skewText:FlxText;
 	var helpText:FlxText;
 
 	// Color variables
 	var offsetColor:FlxColor;
 	var originColor:FlxColor;
-	var hitBoxColor:FlxColor;
 
 	// layers
 	var bgLayer:FlxSprite;
@@ -90,14 +88,14 @@ class FlxSpriteInpsector extends FlxState
 	var animIndex:Int;
 
 	/**
-	* The sprite to be inspected. It represents the object being inspected and
-	* can be an instance of a class that extends FlxSprite or a vanilla FlxSprite.
-	*/
+	 * The sprite to be inspected. It represents the object being inspected and
+	 * can be an instance of a class that extends FlxSprite or a vanilla FlxSprite.
+	 */
 	var sprite = null; // Dynamic
 
 	/**
-	* It initializes and sets up the state's objects and variables.
-	*/
+	 * It initializes and sets up the state's objects and variables.
+	 */
 	override public function create():Void
 	{
 		trace("Hello from FlxSprite Inspector!");
@@ -105,15 +103,12 @@ class FlxSpriteInpsector extends FlxState
 		super.create();
 
 		/**
-		* Create a new instance of the FlxSprite based class and assign it to the 'sprite' variable.
-		* Replace 'DinoSprite' with the name of your custom FlxSprite class.
-		*/
+		 * Create a new instance of the FlxSprite based class and assign it to the 'sprite' variable.
+		 * Replace 'DinoSprite' with the name of your custom FlxSprite class.
+		 */
 		sprite = new DinoSprite();
 
 		bgColor = FlxColor.WHITE;
-		offsetColor = FlxColor.GREEN;
-		originColor = FlxColor.BLUE;
-		hitBoxColor = FlxColor.RED;
 
 		// Initialize the cameras
 		initCameras();
@@ -124,7 +119,7 @@ class FlxSpriteInpsector extends FlxState
 		// create the elements of the inspector
 		bgLayer = new FlxSprite();
 		bgLayer.makeGraphic(FlxG.width * 3, FlxG.height * 3, FlxColor.BLACK);
-		bgLayer.setPosition( -FlxG.width, -FlxG.height);
+		bgLayer.setPosition(-FlxG.width, -FlxG.height);
 		bgLayer.alpha = .1;
 		add(bgLayer);
 
@@ -134,36 +129,43 @@ class FlxSpriteInpsector extends FlxState
 		statusText.cameras = [uiCamera];
 		add(statusText);
 
-		var bottomTextOffset = 35;
-		offsetText = new FlxText(0, FlxG.height - bottomTextOffset, FlxG.width * .2, "offset:[0000, 0000]", 20);
-		offsetText.color = offsetColor;
-		offsetText.alignment = "center";
-		offsetText.cameras = [uiCamera];
-		add(offsetText);
-
-		originText = new FlxText(FlxG.width * .2, FlxG.height - bottomTextOffset, FlxG.width * .2, "origin:[0000, 0000]", 20);
-		originText.color = originColor;
-		originText.alignment = "center";
-		originText.cameras = [uiCamera];
-		add(originText);
-
-		helpText = new FlxText(FlxG.width * .4, FlxG.height - bottomTextOffset, FlxG.width * .2, "Press H for help", 15);
-		helpText.color = FlxColor.BROWN;
+		helpText = new FlxText(FlxG.width * .4, statusText.height, FlxG.width * .2, "Press H for help", 15);
+		helpText.color = FlxColor.PURPLE;
 		helpText.alignment = "center";
 		helpText.cameras = [uiCamera];
 		add(helpText);
 
-		widthText = new FlxText(FlxG.width * .6, FlxG.height - bottomTextOffset, FlxG.width * .2, "width : 0000", 20);
-		widthText.color = FlxColor.GREEN;
-		widthText.alignment = "center";
+		var bottomTextOffset = 35;
+
+		widthText = new FlxText(0, FlxG.height - bottomTextOffset, FlxG.width * .2, "width : 0000", 18);
+		widthText.color = FlxColor.RED;
+		widthText.alignment = "left";
 		widthText.cameras = [uiCamera];
 		add(widthText);
 
-		heightText = new FlxText(FlxG.width * .8, FlxG.height - bottomTextOffset, FlxG.width * .2, "height : 0000", 20);
-		heightText.color = FlxColor.GREEN;
-		heightText.alignment = "center";
+		heightText = new FlxText(FlxG.width * .15, FlxG.height - bottomTextOffset, FlxG.width * .2, "height : 0000", 18);
+		heightText.color = FlxColor.RED;
+		heightText.alignment = "left";
 		heightText.cameras = [uiCamera];
 		add(heightText);
+
+		offsetText = new FlxText(FlxG.width * .35, FlxG.height - bottomTextOffset, FlxG.width * .2, "offset:[0000, 0000]", 18);
+		offsetText.color = FlxColor.GREEN;
+		offsetText.alignment = "left";
+		offsetText.cameras = [uiCamera];
+		add(offsetText);
+
+		originText = new FlxText(FlxG.width * .55, FlxG.height - bottomTextOffset, FlxG.width * .2, "origin:[0000, 0000]", 18);
+		originText.color = FlxColor.BLUE;
+		originText.alignment = "left";
+		originText.cameras = [uiCamera];
+		add(originText);
+
+		skewText = new FlxText(FlxG.width * .75, FlxG.height - bottomTextOffset, FlxG.width * .25, "skew:[0.0000, 0.0000]", 18);
+		skewText.color = FlxColor.ORANGE;
+		skewText.alignment = "left";
+		skewText.cameras = [uiCamera];
+		add(skewText);
 
 		helpScreen = new FlxGroup();
 		helpScreen.cameras = [uiCamera];
@@ -175,7 +177,9 @@ class FlxSpriteInpsector extends FlxState
 		helpBg.makeGraphic(FlxG.width, FlxG.height, 0x77000000);
 		helpScreen.add(helpBg);
 
-		var helpText:FlxText = new FlxText( 10, 100, 800, "Controls: \n \n H : Toggle help visibility on/off \n  \n Mouse Wheel: Zoom in/out. \n  \n Arrow Keys: Move the offset of the sprite by one pixel. \n Shift + Arrow Keys: Move the offset of the sprite by *multiple pixels. \n \n Alt + Arrow Keys: Move the origin of the sprite by one pixel. \n Alt + Shift + Arrow Keys : Move the origin of the sprite by *multiple pixels. \n \n Ctrl + Arrow Keys: Adjust the size of the sprite's hitbox by one pixel. \n Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by *multiple pixels. \n \n Space: Resets all changes. \n \n R: Toggle sprite rotation on/off. \n \n A: Show and play previous animation. \n D: Show and play next animation. \n \n B: Darken the background. \n Shift + B: Lighten the background.\n \n \n *The amount will vary based on the zoom level.", 15);
+		var helpText:FlxText = new FlxText(10, 100, 800,
+			"Controls: \n \n H : Toggle help visibility on/off \n  \n Mouse Wheel: Zoom in/out. \n  \n Arrow Keys: Move the offset of the sprite by one pixel. \n Shift + Arrow Keys: Move the offset of the sprite by *multiple pixels. \n \n Alt + Arrow Keys: Move the origin of the sprite by one pixel. \n Alt + Shift + Arrow Keys : Move the origin of the sprite by *multiple pixels. \n \n Ctrl + Arrow Keys: Adjust the size of the sprite's hitbox by one pixel. \n Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by *multiple pixels. \n \n Space: Resets all changes. \n \n R: Toggle sprite rotation on/off. \n \n A: Show and play previous animation. \n D: Show and play next animation. \n \n B: Darken the background. \n Shift + B: Lighten the background.\n \n \n *The amount will vary based on the zoom level.",
+			15);
 		helpText.color = FlxColor.WHITE;
 		helpScreen.add(helpText);
 
@@ -189,10 +193,10 @@ class FlxSpriteInpsector extends FlxState
 		sprite.screenCenter();
 		add(sprite);
 
-		offsetPoint = new DebugPoint(offsetColor);
+		offsetPoint = new DebugPoint(offsetText.color);
 		add(offsetPoint);
 
-		originPoint = new DebugPoint(originColor);
+		originPoint = new DebugPoint(originText.color);
 		add(originPoint);
 
 		// initialize variables
@@ -208,13 +212,17 @@ class FlxSpriteInpsector extends FlxState
 		if (animNames.length > 0)
 		{
 			sprite.animation.play(animNames[0]);
-			statusText.text = "The sprite has " + Std.string(animNames.length) + (animNames.length == 1 ? " animation : '" : " animations. Current : '") + sprite.animation.name + "'";
+			statusText.text = "The sprite has "
+				+ Std.string(animNames.length)
+				+ (animNames.length == 1 ? " animation : '" : " animations. Current : '")
+				+ sprite.animation.name
+				+ "'";
 		}
-		else statusText.text = "The sprite does not have any animation.";
+		else
+			statusText.text = "The sprite does not have any animation.";
 
 		// set the initial zoom
-		gCamera.zoom = FlxG.width >= FlxG.height ? (FlxG.width / sprite.width) * .4: (FlxG.height / sprite.height) * .4;
-
+		gCamera.zoom = FlxG.width >= FlxG.height ? (FlxG.width / sprite.width) * .4 : (FlxG.height / sprite.height) * .4;
 	}
 
 	override public function update(elapsed:Float):Void
@@ -223,7 +231,7 @@ class FlxSpriteInpsector extends FlxState
 
 		// draw the inpected sprite properties
 		hitBoxLayer.fill(FlxColor.TRANSPARENT);
-		hitBoxLayer.drawRect(sprite.x, sprite.y, sprite.width, sprite.height, FlxColor.TRANSPARENT, {color: hitBoxColor});
+		hitBoxLayer.drawRect(sprite.x, sprite.y, sprite.width, sprite.height, FlxColor.TRANSPARENT, {color: widthText.color});
 		originPoint.drawCross(sprite.x + sprite.origin.x, sprite.y + sprite.origin.y, 5);
 		offsetPoint.drawCross(sprite.x + sprite.offset.x, sprite.y + sprite.offset.y, 5);
 
@@ -237,15 +245,19 @@ class FlxSpriteInpsector extends FlxState
 		if (FlxG.mouse.wheel != 0)
 		{
 			var wheelValue:Int = FlxG.mouse.wheel;
-			if (wheelValue < -6) wheelValue = -6;
-			if (wheelValue > 6) wheelValue = 6;
-			
+			if (wheelValue < -6)
+				wheelValue = -6;
+			if (wheelValue > 6)
+				wheelValue = 6;
+
 			gCamera.zoom += (wheelValue);
 
 			// Limit the zoom within a certain range
-			if (gCamera.zoom < 0) gCamera.zoom = 0;
+			if (gCamera.zoom < 0)
+				gCamera.zoom = 0;
 			var maxZoom = FlxG.width >= FlxG.height ? (FlxG.width / sprite.width) * .8 : (FlxG.height / sprite.height) * .8;
-			if (gCamera.zoom > maxZoom) gCamera.zoom = maxZoom;
+			if (gCamera.zoom > maxZoom)
+				gCamera.zoom = maxZoom;
 
 			statusText.text = "Adjusting zoom";
 
@@ -266,8 +278,10 @@ class FlxSpriteInpsector extends FlxState
 		// Press B/Shift+B to adjust the background lightness
 		if (FlxG.keys.justPressed.B)
 		{
-			if (FlxG.keys.pressed.SHIFT) bgLayer.alpha = Math.max(0, bgLayer.alpha - 0.1);
-			else bgLayer.alpha = Math.min(1, bgLayer.alpha + 0.1);
+			if (FlxG.keys.pressed.SHIFT)
+				bgLayer.alpha = Math.max(0, bgLayer.alpha - 0.1);
+			else
+				bgLayer.alpha = Math.min(1, bgLayer.alpha + 0.1);
 
 			statusText.text = "Adjusting background lightness";
 		}
@@ -277,7 +291,8 @@ class FlxSpriteInpsector extends FlxState
 		{
 			animIndex--;
 
-			if (animIndex < 0) animIndex = animNames.length - 1;
+			if (animIndex < 0)
+				animIndex = animNames.length - 1;
 			sprite.animation.play(animNames[animIndex]);
 			statusText.text = "Playing animation : '" + sprite.animation.name + "'";
 		}
@@ -287,7 +302,8 @@ class FlxSpriteInpsector extends FlxState
 		{
 			animIndex++;
 
-			if (animIndex >= animNames.length) animIndex = 0;
+			if (animIndex >= animNames.length)
+				animIndex = 0;
 			sprite.animation.play(animNames[animIndex]);
 			statusText.text = "Playing animation : '" + sprite.animation.name + "'";
 		}
@@ -299,7 +315,8 @@ class FlxSpriteInpsector extends FlxState
 			if (FlxG.keys.pressed.SHIFT)
 			{
 				sprite.angle = 0;
-				if (canRotate) canRotate = false;
+				if (canRotate)
+					canRotate = false;
 
 				statusText.text = "Rotation has been reset.";
 			}
@@ -310,7 +327,8 @@ class FlxSpriteInpsector extends FlxState
 			}
 		}
 
-		if (canRotate) sprite.angle++;
+		if (canRotate)
+			sprite.angle++;
 
 		// Listen for short press on arrow keys
 		var jLeft:Int = FlxG.keys.justPressed.LEFT ? -1 : 0;
@@ -360,7 +378,8 @@ class FlxSpriteInpsector extends FlxState
 			keyTimer += elapsed;
 
 			// Check if enough time has passed while the key is held down
-			if (keyTimer < keyTimerDelay) return;
+			if (keyTimer < keyTimerDelay)
+				return;
 
 			// Use a differnt different modifier in this case
 			transformModifier = FlxG.keys.pressed.SHIFT ? Math.round(10 / (FlxG.camera.zoom * .5)) : 1;
@@ -418,7 +437,8 @@ class FlxSpriteInpsector extends FlxState
 			keyTimer += elapsed;
 
 			// Check if enough time has passed while the key is held down
-			if (keyTimer < keyTimerDelay) return;
+			if (keyTimer < keyTimerDelay)
+				return;
 
 			// Use a differnt different modifier in this case
 			transformModifier = FlxG.keys.pressed.SHIFT ? Math.round(10 / (FlxG.camera.zoom * .5)) : 1;
@@ -451,12 +471,12 @@ class FlxSpriteInpsector extends FlxState
 	}
 
 	/**
-	* Initializes the cameras used in the inspector.
-	* Creates a UI camera and a graphics camera with the same dimensions as the screen.
-	* Sets the background color of the game camera to white and the UI camera to transparent.
-	* Adds the graphics camera as the active camera.
-	* Adds the UI camera and sets it as the non-active camera.
-	*/
+	 * Initializes the cameras used in the inspector.
+	 * Creates a UI camera and a graphics camera with the same dimensions as the screen.
+	 * Sets the background color of the game camera to white and the UI camera to transparent.
+	 * Adds the graphics camera as the active camera.
+	 * Adds the UI camera and sets it as the non-active camera.
+	 */
 	function initCameras():Void
 	{
 		uiCamera = new FlxCamera(0, 0, FlxG.width, FlxG.height);
@@ -468,5 +488,4 @@ class FlxSpriteInpsector extends FlxState
 		FlxG.cameras.reset(gCamera);
 		FlxG.cameras.add(uiCamera, false);
 	}
-
 }

--- a/source/helpers/FlxSpriteInpsector.hx
+++ b/source/helpers/FlxSpriteInpsector.hx
@@ -9,6 +9,7 @@ import flixel.math.FlxPoint;
 import flixel.text.FlxText;
 import flixel.util.FlxColor;
 import helpers.graphics.DebugPoint;
+import flixel.math.FlxAngle;
 
 using flixel.util.FlxSpriteUtil;
 
@@ -36,13 +37,15 @@ using flixel.util.FlxSpriteUtil;
 	*                              The amount will vary based on the zoom level.
 	* Ctrl + Arrow Keys          : Adjust the size of the sprite's hitbox by one pixel.
 	* Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by multiple pixels.
-	*                              The amount will vary based on the zoom level.
-	* Space                      : Resets all changes.
+	* IJKL                       : Skew the sprite by one degree. 
+	* Shift + IJKL               : Skew the sprite by multiple degrees.
 	* R                          : Toggle sprite rotation on/off.
+	* Space                      : Resets all changes.
 	* A                          : Show and play previous animation.
 	* D                          : Show and play next animation.
 	* B                          : Darken the background.
 	* Shift + B                  : Lighten the background.
+	* *The amount will vary based on the zoom level.
 	*----------------------------------------------------------------------------------------
  */
 class FlxSpriteInpsector extends FlxState
@@ -161,7 +164,7 @@ class FlxSpriteInpsector extends FlxState
 		originText.cameras = [uiCamera];
 		add(originText);
 
-		skewText = new FlxText(FlxG.width * .75, FlxG.height - bottomTextOffset, FlxG.width * .25, "skew:[0.0000, 0.0000]", 18);
+		skewText = new FlxText(FlxG.width * .75, FlxG.height - bottomTextOffset, FlxG.width * .25, "skew:[0.000, 0.000]", 18);
 		skewText.color = FlxColor.ORANGE;
 		skewText.alignment = "left";
 		skewText.cameras = [uiCamera];
@@ -178,7 +181,7 @@ class FlxSpriteInpsector extends FlxState
 		helpScreen.add(helpBg);
 
 		var helpText:FlxText = new FlxText(10, 100, 800,
-			"Controls: \n \n H : Toggle help visibility on/off \n  \n Mouse Wheel: Zoom in/out. \n  \n Arrow Keys: Move the offset of the sprite by one pixel. \n Shift + Arrow Keys: Move the offset of the sprite by *multiple pixels. \n \n Alt + Arrow Keys: Move the origin of the sprite by one pixel. \n Alt + Shift + Arrow Keys : Move the origin of the sprite by *multiple pixels. \n \n Ctrl + Arrow Keys: Adjust the size of the sprite's hitbox by one pixel. \n Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by *multiple pixels. \n \n Space: Resets all changes. \n \n R: Toggle sprite rotation on/off. \n \n A: Show and play previous animation. \n D: Show and play next animation. \n \n B: Darken the background. \n Shift + B: Lighten the background.\n \n \n *The amount will vary based on the zoom level.",
+			"Controls: \n \n H : Toggle help visibility on/off \n  \n Mouse Wheel: Zoom in/out. \n  \n Arrow Keys: Move the offset of the sprite by one pixel. \n Shift + Arrow Keys: Move the offset of the sprite by *multiple pixels. \n \n Alt + Arrow Keys: Move the origin of the sprite by one pixel. \n Alt + Shift + Arrow Keys : Move the origin of the sprite by *multiple pixels. \n \n Ctrl + Arrow Keys: Adjust the size of the sprite's hitbox by one pixel. \n Ctrl + Shift + Arrow Keys  : Adjust the size of the sprite's hitbox by *multiple pixels. \n \n IJKL: Skew the sprite by one degree. \n Shift + IJKL: Skew the sprite by multiple degrees. \n \n R: Toggle sprite rotation on/off. \n \n Space: Reset all changes. \n \n A: Show and play previous animation. \n D: Show and play next animation. \n \n B: Darken the background. \n Shift + B: Lighten the background.\n \n \n *The amount will vary based on the zoom level.",
 			15);
 		helpText.color = FlxColor.WHITE;
 		helpScreen.add(helpText);
@@ -270,6 +273,7 @@ class FlxSpriteInpsector extends FlxState
 		{
 			sprite.angle = 0;
 			canRotate = false;
+			sprite.skew.set(0, 0);
 			sprite.updateHitbox();
 
 			statusText.text = "Changes have been reset";
@@ -342,8 +346,60 @@ class FlxSpriteInpsector extends FlxState
 		var pUp:Int = FlxG.keys.pressed.UP ? -1 : 0;
 		var pDown:Int = FlxG.keys.pressed.DOWN ? 1 : 0;
 
+		// Listen for short press on the IKJL keys
+		var jI:Int = FlxG.keys.justPressed.I ? 1 : 0;
+		var pI:Int = FlxG.keys.pressed.I ? 1 : 0;
+		var jK:Int = FlxG.keys.justPressed.K ? 1 : 0;
+		var pK:Int = FlxG.keys.pressed.K ? 1 : 0;
+
+		// Listen for long press on the IKJL keys
+		var jJ:Int = FlxG.keys.justPressed.J ? 1 : 0;
+		var pJ:Int = FlxG.keys.pressed.J ? 1 : 0;
+		var jL:Int = FlxG.keys.justPressed.L ? 1 : 0;
+		var pL:Int = FlxG.keys.pressed.L ? 1 : 0;
+
 		// Hold SHIFT to apply the transform modifier
 		transformModifier = FlxG.keys.pressed.SHIFT ? Math.round(10 / (FlxG.camera.zoom * .25)) : 1;
+
+		if (jI + jK != 0)
+		{
+			keyTimer = 0; // Reset the timer of long press
+			sprite.skew.y += (jI - jK) * transformModifier;
+			statusText.text = "Adjusting skew.";
+		}
+
+		if (pI + pK != 0)
+		{
+			keyTimer += elapsed;
+
+			if (keyTimer < keyTimerDelay)
+				return;
+
+			transformModifier = FlxG.keys.pressed.SHIFT ? Math.round(10 / (FlxG.camera.zoom * .5)) : 1;
+
+			sprite.skew.y += (pI - pK) * transformModifier;
+			statusText.text = "Adjusting skew.";
+		}
+
+		if (jJ + jL != 0)
+		{
+			keyTimer = 0; // Reset the timer of long press
+			sprite.skew.x += (jJ - jL) * transformModifier;
+			statusText.text = "Adjusting skew.";
+		}
+
+		if (pJ + pL != 0)
+		{
+			keyTimer += elapsed;
+
+			if (keyTimer < keyTimerDelay)
+				return;
+
+			transformModifier = FlxG.keys.pressed.SHIFT ? Math.round(10 / (FlxG.camera.zoom * .5)) : 1;
+
+			sprite.skew.x += (pJ - pL) * transformModifier;
+			statusText.text = "Adjusting skew.";
+		}
 
 		// Check if either the LEFT or RIGHT arrow key has been pressed
 		if (jLeft + jRight != 0)
@@ -463,11 +519,12 @@ class FlxSpriteInpsector extends FlxState
 			}
 		}
 
-		// Update the text fields with the current sprite properties: offset, origin, width, and height.
-		offsetText.text = "offset : [" + Std.string(sprite.offset.x) + ", " + Std.string(sprite.offset.y) + "]";
-		originText.text = "origin : [" + Std.string(sprite.origin.x) + ", " + Std.string(sprite.origin.y) + "]";
-		widthText.text = "width : " + Std.string(sprite.width);
-		heightText.text = "height : " + Std.string(sprite.height);
+		// Update the text fields with the current sprite properties: offset, origin, width height, and skew.
+		widthText.text = 'width : [${Std.string(sprite.width)}]';
+		heightText.text = 'height : [${Std.string(sprite.height)}]';
+		offsetText.text = 'offset : [${Std.string(sprite.offset.x)}, ${Std.string(sprite.offset.y)}]';
+		originText.text = 'origin : [${Std.string(sprite.origin.x)}, ${Std.string(sprite.origin.y)}]';
+		skewText.text = 'skew : [${(Std.string(Math.tan(sprite.skew.x * FlxAngle.TO_RAD))).substring(0, 6)}, ${Std.string(Math.tan(sprite.skew.y * FlxAngle.TO_RAD)).substring(0, 6)}]';
 	}
 
 	/**


### PR DESCRIPTION

## ..Woke up one day, and chose open source!
This PR uses FlxSkewedSprite from the flixel addons package to expose one of the FlxSprite's lesser-known matrix properties: skew.

https://github.com/harpwood/FlxSprite-Inspector/assets/95124554/8d885152-a603-495b-9ab5-7c1ad5f25821

Pressing IJKL will skew the sprite by one degree, or multiple if shift is held.

## Related Suggestions:
* Adjust the fonts' borders and colors so they are legibly distinct from the inspector elements
* Use a more convenient measurement for skewing
* Make your own FlxSprite class that exposes more functionalities
* Implement a cross-platform file browser to load images/animations
* Experiment with flixel ui or the flixel debugger for more control
* Add mouse support to free up keys
